### PR TITLE
Change `yarn lint` command to not use `--fix` for CI

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -12,7 +12,8 @@
     "start-console": "./start-console.sh",
     "i18n": "i18next \"src/**/*.{js,jsx,ts,tsx}\" [-oc] -c i18next-parser.config.js",
     "ts-node": "ts-node -O '{\"module\":\"commonjs\"}'",
-    "lint": "eslint ./src --fix && stylelint \"src/**/*.css\" --allow-empty-input --fix"
+    "lint": "eslint ./src && stylelint \"src/**/*.css\" --allow-empty-input",
+    "lint-fix": "eslint ./src --fix && stylelint \"src/**/*.css\" --allow-empty-input --fix"
   },
   "devDependencies": {
     "@openshift-console/dynamic-plugin-sdk": "0.0.12",


### PR DESCRIPTION
We want to run lint as part of our CI tests, so change this command to not automatically fix any lint errors found.

Add a separate `yarn lint-fix` command for development.