### PR TITLE
OU-220: Remove insecure CORS header

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -31,7 +31,6 @@ func Start(cfg *Config) error {
 	go datasourceManager.WatchDatasources(cfg.DashboardsNamespace)
 
 	muxRouter := mux.NewRouter()
-	muxRouter.Use(corsHeaderMiddleware(cfg))
 
 	loggedRouter := handlers.LoggingHandler(log.Logger.Out, muxRouter)
 
@@ -81,14 +80,4 @@ func healthHandler() http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("ok"))
 	})
-}
-
-func corsHeaderMiddleware(cfg *Config) func(next http.Handler) http.Handler {
-	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			headers := w.Header()
-			headers.Set("Access-Control-Allow-Origin", "*")
-			next.ServeHTTP(w, r)
-		})
-	}
 }


### PR DESCRIPTION
This PR removes unused insecure CORS headers, the plugin will use the console proxy which is on the same domain so this is not required.