### PR TITLE
OU-400: add command flag to customize the namespace tracked for datasources

### DIFF
--- a/cmd/plugin-backend.go
+++ b/cmd/plugin-backend.go
@@ -10,12 +10,13 @@ import (
 )
 
 var (
-	portArg       = flag.Int("port", 0, "server port to listen on (default: 9004)")
-	certArg       = flag.String("cert", "", "cert file path to enable TLS (disabled by default)")
-	keyArg        = flag.String("key", "", "private key file path to enable TLS (disabled by default)")
-	staticPathArg = flag.String("static-path", "", "static files path to serve frontend (default: './web/dist')")
-	logLevel      = flag.String("loglevel", "info", "log level (default: info)")
-	log           = logrus.WithField("module", "main")
+	portArg                = flag.Int("port", 0, "server port to listen on (default: 9004)")
+	certArg                = flag.String("cert", "", "cert file path to enable TLS (disabled by default)")
+	keyArg                 = flag.String("key", "", "private key file path to enable TLS (disabled by default)")
+	staticPathArg          = flag.String("static-path", "", "static files path to serve frontend (default: './web/dist')")
+	dashboardsNamespaceArg = flag.String("dashboards-namespace", "", "namespace to watch for custom datasources for dashboards (default: 'console-dashboards')")
+	logLevel               = flag.String("loglevel", "info", "log level (default: info)")
+	log                    = logrus.WithField("module", "main")
 )
 
 func main() {
@@ -25,6 +26,7 @@ func main() {
 	cert := mergeEnvValue("CERT_FILE_PATH", *certArg, "")
 	key := mergeEnvValue("PRIVATE_KEY_FILE_PATH", *keyArg, "")
 	staticPath := mergeEnvValue("STATIC_PATH", *staticPathArg, "./web/dist")
+	dashboardsNamespace := mergeEnvValue("DASHBOARDS_NAMESPACE", *dashboardsNamespaceArg, "console-dashboards")
 
 	lvl, err := logrus.ParseLevel(*logLevel)
 	if err != nil {
@@ -39,7 +41,7 @@ func main() {
 		CertFile:            cert,
 		PrivateKeyFile:      key,
 		StaticPath:          staticPath,
-		DashboardsNamespace: "console-dashboards",
+		DashboardsNamespace: dashboardsNamespace,
 	})
 }
 


### PR DESCRIPTION
This PR adds a new `dashboards-namespace` command option and env var `DASHBOARDS_NAMESPACE` so the namespace that is watched for custom datasources can be configured