### PR TITLE
OU-413: reset proxy so is re created when the datasource changes

### DIFF
--- a/docs/prometheus-datasource-example.yaml
+++ b/docs/prometheus-datasource-example.yaml
@@ -15,5 +15,4 @@ data:
       plugin:
         kind: "prometheus"
         spec:
-          direct_url = "https://prometheus-k8s.openshift-monitoring.svc.cluster.local.9091"
-
+          direct_url: "https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091"

--- a/pkg/datasources/manager.go
+++ b/pkg/datasources/manager.go
@@ -34,6 +34,8 @@ func NewDatasourceManager() *DatasourceManager {
 func (manager *DatasourceManager) SetDatasource(datasourceName string, datasource *DataSource) {
 	manager.mutex.Lock()
 	(*manager.datasourceMap)[datasourceName] = datasource
+	// Set the proxy to nil so that it will be recreated
+	(*manager.proxiesMap)[datasourceName] = nil
 	manager.mutex.Unlock()
 }
 


### PR DESCRIPTION
This PR resets the proxy when the datasource changes in order to re create it