### PR TITLE
add validation when ca does not exists, fix add datasource docs

### DIFF
--- a/docs/add-datasource.md
+++ b/docs/add-datasource.md
@@ -91,5 +91,9 @@ data:
         kind: "PrometheusDatasource"
         spec:
           direct_url: "https://my-custom-prometheus-service.my-service-namespace.svc.cluster.local:9091"
-  'dashboard-datasource-ca': '-----BEGIN CERTIFICATE-----\nMIID....'
+  'dashboard-datasource-ca': |-
+    -----BEGIN CERTIFICATE-----
+    ....
+    ....
+    -----END CERTIFICATE-----
 ```

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -68,6 +68,11 @@ func getProxy(datasourceName string, serviceCAfile string, datasourceManager *da
 		}
 	}
 
+	if len(serviceCertPEM) == 0 {
+		log.Errorf("no certificate provided. Proxy to datasource '%s' will fail", datasourceName)
+		return nil
+	}
+
 	serviceProxyRootCAs := x509.NewCertPool()
 	if !serviceProxyRootCAs.AppendCertsFromPEM(serviceCertPEM) {
 		log.Errorf("no CA found or is invalid. Proxy to datasource '%s' will fail", datasourceName)


### PR DESCRIPTION
This PR validates that a CA with content is provided and fixes documentation