### PR TITLE
OU-446: Support FIPS

### DIFF
--- a/Dockerfile.art
+++ b/Dockerfile.art
@@ -10,10 +10,10 @@ USER 0
 ARG YARN_VERSION=v1.22.19
 RUN CACHED_YARN=../artifacts/yarn-${YARN_VERSION}.tar.gz; \
     if [ -f ${CACHED_YARN} ]; then \
-      npm install -g ${CACHED_YARN}; \
+    npm install -g ${CACHED_YARN}; \
     else \
-      echo "need yarn at ${CACHED_YARN}"; \
-      exit 1; \
+    echo "need yarn at ${CACHED_YARN}"; \
+    exit 1; \
     fi
 
 # use dependencies provided by Cachito
@@ -21,10 +21,10 @@ ENV HUSKY=0
 RUN test -d ${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps || exit 1; \
     cp -f $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app/web/{.npmrc,.yarnrc,yarn.lock} . \
     && cp -f $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app/registry-ca.pem .. \
- && source ${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps/cachito.env \
- && yarn && yarn build
+    && source ${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps/cachito.env \
+    && yarn && yarn build
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.14 AS go-builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17 AS go-builder
 
 COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR
 WORKDIR /go/src/github.com/openshift/console-dashboards-plugin
@@ -35,9 +35,12 @@ COPY cmd/ cmd/
 COPY pkg/ pkg/
 COPY Makefile Makefile
 
-RUN source ${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps/cachito.env && make build-backend
+ENV GOEXPERIMENT=strictfipsruntime
+ENV CGO_ENABLED=1
 
-FROM registry.ci.openshift.org/ocp/4.14:base
+RUN source ${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps/cachito.env && make build-backend BUILD_OPTS="-tags strictfipsruntime"
+
+FROM registry.ci.openshift.org/ocp/4.17:base-rhel9
 
 COPY --from=web-builder /opt/app-root/src/app/web/dist /usr/share/web/dist
 COPY --from=go-builder /go/src/github.com/openshift/console-dashboards-plugin/plugin-backend /usr/bin/plugin-backend
@@ -46,8 +49,8 @@ USER 1001
 WORKDIR /usr/bin
 
 LABEL io.k8s.display-name="OpenShift console dashboards plugin" \
-      io.k8s.description="This is an OpenShift console plugin to enhance dashboards." \
-      io.openshift.tags="openshift" \
-      maintainer="Observability UI Team <team-observability-ui@redhat.com>"
+    io.k8s.description="This is an OpenShift console plugin to enhance dashboards." \
+    io.openshift.tags="openshift" \
+    maintainer="Observability UI Team <team-observability-ui@redhat.com>"
 
 ENTRYPOINT ["/usr/bin/plugin-backend", "-static-path", "/usr/share/web/dist"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,5 @@
-FROM registry.redhat.io/ubi8/nodejs-18:latest AS web-builder
+# This Dockerfile is used for local testing of images. All images should be available for public use
+FROM registry.redhat.io/ubi9/nodejs-18:latest AS web-builder
 
 WORKDIR /opt/app-root
 
@@ -11,7 +12,7 @@ RUN make install-frontend-ci-clean
 COPY web/ web/
 RUN make build-frontend
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.22-openshift-4.17 as go-builder
+FROM quay.io/redhat-cne/openshift-origin-release:rhel-9-golang-1.22-openshift-4.17 as go-builder
 
 WORKDIR /opt/app-root
 
@@ -24,12 +25,9 @@ RUN go mod download
 COPY cmd/ cmd/
 COPY pkg/ pkg/
 
-ENV GOEXPERIMENT=strictfipsruntime
-ENV CGO_ENABLED=1
+RUN make build-backend
 
-RUN make build-backend BUILD_OPTS="-tags strictfipsruntime"
-
-FROM registry.access.redhat.com/ubi8/ubi
+FROM registry.access.redhat.com/ubi9/ubi-minimal
 
 COPY --from=web-builder /opt/app-root/web/dist /opt/app-root/web/dist
 COPY --from=go-builder /opt/app-root/plugin-backend /opt/app-root

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ test-unit-backend:
 
 .PHONY: build-backend
 build-backend:
-	go build -o plugin-backend cmd/plugin-backend.go
+	go build $(BUILD_OPTS) -o plugin-backend -mod=readonly cmd/plugin-backend.go
 
 .PHONY: start-backend
 start-backend:
@@ -50,5 +50,5 @@ build-image:
 install: install-frontend install-backend
 
 .PHONY: example
-example: 
+example:
 	cd docs && oc apply -f prometheus-datasource-example.yaml && oc apply -f prometheus-dashboard-example.yaml

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/console-dashboards-plugin
 
-go 1.20
+go 1.22.5
 
 require (
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2

--- a/go.sum
+++ b/go.sum
@@ -162,7 +162,9 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8m
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/onsi/ginkgo/v2 v2.4.0 h1:+Ig9nvqgS5OBSACXNk15PLdp0U9XPYROt9CFzVdFGIs=
+github.com/onsi/ginkgo/v2 v2.4.0/go.mod h1:iHkDK1fKGcBoEHT5W7YBq4RFWaQulw+caOMkAt4OrFo=
 github.com/onsi/gomega v1.23.0 h1:/oxKu9c2HVap+F3PfKort2Hw5DEU+HGlW8n+tguWsys=
+github.com/onsi/gomega v1.23.0/go.mod h1:Z/NWtiqwBrwUt4/2loMmHL63EDLnYHmVbuBpDr2vQAg=
 github.com/openshift/library-go v0.0.0-20230130232623-47904dd9ff5a h1:OzF7I7mAzO4SBo5eO5CWoCTgMDydN/Tf2/Rq8YbMpT0=
 github.com/openshift/library-go v0.0.0-20230130232623-47904dd9ff5a/go.mod h1:xO4nAf0qa56dgvEJWVD1WuwSJ8JWPU1TYLBQrlutWnE=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -172,6 +174,7 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
 github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -17,7 +17,7 @@ BASE_IMAGE="quay.io/${REGISTRY_ORG}/console-dashboards-plugin"
 IMAGE=${BASE_IMAGE}:${TAG}
 
 echo "Building image '${IMAGE}' with ${OCI_BIN}"
-$OCI_BIN build -t $IMAGE .
+$OCI_BIN build -t $IMAGE -f Dockerfile.dev .
 
 if [[ $PUSH == 1 ]]; then
     $OCI_BIN push $IMAGE


### PR DESCRIPTION
This PR looks to add FIPS support to the console-dashboard-plugin. It updates the go version to 1.22, and uses recommended FIPS compliant images and tags. Due to some of the recommended images not being available publicly a Dockerfile.dev is added to the repo as a way to build and test images locally.