### PR TITLE
OU-675: Update to golang v1.23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN make install-frontend-ci-clean
 COPY web/ web/
 RUN make build-frontend
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.22-openshift-4.17 as go-builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 as go-builder
 
 WORKDIR /opt/app-root
 

--- a/Dockerfile.art
+++ b/Dockerfile.art
@@ -24,7 +24,7 @@ RUN test -d ${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps || exit 1; \
     && source ${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps/cachito.env \
     && yarn && yarn build
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17 AS go-builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 AS go-builder
 
 COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR
 WORKDIR /go/src/github.com/openshift/console-dashboards-plugin

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -12,7 +12,7 @@ RUN make install-frontend-ci-clean
 COPY web/ web/
 RUN make build-frontend
 
-FROM quay.io/redhat-cne/openshift-origin-release:rhel-9-golang-1.22-openshift-4.17 as go-builder
+FROM quay.io/redhat-cne/openshift-origin-release:rhel-9-golang-1.23-openshift-4.19 as go-builder
 
 WORKDIR /opt/app-root
 
@@ -25,7 +25,7 @@ RUN go mod download
 COPY cmd/ cmd/
 COPY pkg/ pkg/
 
-RUN make build-backend
+RUN make build-backend-dev
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal
 

--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -12,7 +12,7 @@ RUN make install-frontend-ci
 COPY web/ web/
 RUN make build-frontend
 
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.22 as go-builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23 as go-builder
 
 WORKDIR /opt/app-root
 

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,12 @@ test-unit-backend:
 build-backend:
 	go build $(BUILD_OPTS) -o plugin-backend -mod=readonly cmd/plugin-backend.go
 
+# docker inspect --format '{{.Architecture}}' quay.io/redhat-cne/openshift-origin-release:rhel-9-golang-1.23-openshift-4.19
+# base image above has a arm64 archiecture; need to build executable /plugin-backend as amd64 to be match final container archiecture 
+.PHONY: build-backend-dev
+build-backend-dev:
+	GOARCH=amd64 GOOS=linux go build -mod=readonly -o plugin-backend -mod=readonly cmd/plugin-backend.go
+
 .PHONY: start-backend
 start-backend:
 	go run ./cmd/plugin-backend.go

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/console-dashboards-plugin
 
-go 1.22.1
+go 1.23
 
 require (
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2


### PR DESCRIPTION
## JIRA 

## Description 
Update to golang v1.23
- Update go.mod
- Update Dockerfile to use base images with golang 1.23 and openshift 4.19

### Process 
- [X] 1. Manually update `go.mod` to 1.23. Then run `go mod tidy`
- [X] 2. Replace base image with go v1.22 with go v1.23 
    - registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 (Dockerfile, Dockerfile.art)
    - quay.io/redhat-cne/openshift-origin-release:rhel-9-golang-1.23-openshift-4.19 (Dockerfile.dev)
- [X *see note] 3. Testing build and run without error 
    - [x] 3.1 Dockerfile.konflux 
        - [x] `docker build -f Dockerfile.konflux -t console-dashboard-plugin-go1.23 .`
        - [x] `docker run docker.io/library/console-dashboard-plugin-go1.23:latest`
    - [X] 3.2 Dockerfile.dev 
        - [X] Update Makefile with command `make build-backend-dev` to explicitly require /plugin-plugin to be compatible with AMD64 architecture (this is to ensure the executable /plugin-backend can be copied and run in final image which has AMD64 archiecture)
        - [X] `docker build -f Dockerfile.dev -t console-dashboard-plugin-dev-go1.23 .`
        - [X] `docker run docker.io/library/console-dashboard-plugin-dev-go1.23:latest`
 
*Note: Did not test Dockerfile or Dockerfile.art because I do not have the credentials for registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19
        - I assume we can validate the Dockerfile files if they pass the prow tests on this PR
        - This image was found to be used in github.com/openshift/release https://github.com/search?q=repo%3Aopenshift%2Frelease++registry.ci.openshift.org%2Focp%2Fbuilder%3Arhel-9-golang-1.23-openshift-4.19&type=code&p=2

### Troubleshooting 

#### Build and Enter a image 
`docker build -f Dockerfile.dev -t console-dashboard-plugin-dev-go1.23-test1:latest .`
`docker run -it --entrypoint /bin/bash docker.io/library/console-dashboard-plugin-dev-go1.23-test1:latest`

#### Why do we need to specify the GOARCH
`GOARCH=amd64 GOOS=linux go build -mod=readonly -o plugin-backend -mod=readonly cmd/plugin-backend.go`
Creates an executable (e.g. /plugin-backend.go) that will work on a specific architecture (e.g. amd64) because the executable will have different instructions based on the architecture type (e.g. AMD64 vs. ARM64). 

The GOARCH environment variable in Go specifies the target architecture of the system you're building for. Architecture refers to the design of the computer's CPU and how it processes data. Different CPU architectures support different instruction sets and capabilities, which affect how the compiled program works.

1. Wrong Architecture
Since the binary is statically linked, an architecture mismatch could still be the issue. If the binary was compiled for a different architecture than the one running in your container (e.g., compiling for amd64 but running in an arm64 container), it won't run correctly.

#### Dockerfile.dev
#### Before 
docker inspect --format '{{.Architecture}}' registry.redhat.io/ubi9/nodejs-18:latest
amd64
docker inspect --format '{{.Architecture}}' quay.io/redhat-cne/openshift-origin-release:rhel-9-golang-1.22-openshift-4.17
amd64
docker inspect --format '{{.Architecture}}' registry.access.redhat.com/ubi9/ubi-minimal
amd64

#### After -- Broken
 docker run -it docker.io/library/logging-view-plugin-go1.23:dev-3 /bin/bash
{"msg":"exec container process (missing dynamic library?) `/opt/app-root/plugin-backend`: No such file or directory","level":"error","time":"2025-03-03T21:10:55.160579Z"}

Because /plugin-backend executable was a 
docker inspect --format '{{.Architecture}}' registry.redhat.io/ubi9/nodejs-18:latest
amd64
docker inspect --format '{{.Architecture}}' quay.io/redhat-cne/openshift-origin-release:rhel-9-golang-1.23-openshift-4.19
arm64
docker inspect --format '{{.Architecture}}' registry.access.redhat.com/ubi9/ubi-minimal
amd64

SOLUTION: Explicitly require GOARCH=amd64 GOOS=linux so executable /plugin-backend has a compatible archiecture with final image its copied into registry.access.redhat.com/ubi9/ubi-minimal, which has amd64 arch 
```
# Dockerfile.dev
`RUN make build-backend-dev` 

# Makefile 
.PHONY: build-backend-dev
build-backend-dev:
	GOARCH=amd64 GOOS=linux  go build -mod=readonly -o plugin-backend -mod=readonly cmd/plugin-backend.go
```

#### Dockerfile.konflux
#### Build stage base-image
docker inspect --format '{{.Architecture}}' brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23 
arm64
#### Final stage base-image 
docker inspect --format '{{.Architecture}}' registry.redhat.io/rhel9-2-els/rhel:9.2
arm64

#### Manually build /plugin-backend using base-image 
```
# Pull and Run image 
docker pull quay.io/redhat-cne/openshift-origin-release:rhel-9-golang-1.23-openshift-4.19
docker run -it quay.io/redhat-cne/openshift-origin-release:rhel-9-golang-1.23-openshift-4.19 /bin/bash

# Copy local files into base image 
docker cp /path/to/your/go/project <container_id>:/path/to/project
docker cp /Users/jezhu/Git/logging-view-plugin/Makefile 98afec1b696c:/opt/app-root/Makefile
docker cp /Users/jezhu/Git/logging-view-plugin/go.mod 98afec1b696c:/opt/app-root/go.mod
docker cp /Users/jezhu/Git/logging-view-plugin/go.sum 98afec1b696c:/opt/app-root/go.sum
docker cp /Users/jezhu/Git/logging-view-plugin/config 98afec1b696c:/opt/app-root/config
docker cp /Users/jezhu/Git/logging-view-plugin/cmd 98afec1b696c:/opt/app-root/cmd
docker cp /Users/jezhu/Git/logging-view-plugin/pkg 98afec1b696c:/opt/app-root/pkg
docker cp /Users/jezhu/Git/logging-view-plugin/web/dist 98afec1b696c:/opt/app-root/web/dist

# Find the container_id of quay.io/redhat-cne/openshift-origin-release:rhel-9-golang-1.23-openshift-4.19
# Then explore file system of the image, make sure your images were copied correctly
docker ps 
docker exec -it <container_id> /bin/bash
docker exec -it 98afec1b696c /bin/bash

# While in the base image 
make install-backend
make build-backend 

```